### PR TITLE
fix: frontend — template deploy, auth, sessions, assignees, logout

### DIFF
--- a/desktop/src/lib/api/client.ts
+++ b/desktop/src/lib/api/client.ts
@@ -84,9 +84,21 @@ async function getMock() {
  * Enable mock mode and notify the mock module so its internal guard allows
  * handleRequest calls. Also clears the response cache to prevent stale real
  * data from being served after a reconnect cycle.
+ *
+ * When transitioning FROM mock TO real mode, a transition gate is raised so
+ * in-flight requests are held until the cache is cleared and re-auth completes,
+ * preventing a mixed mock/real state.
  */
 async function setMockEnabled(enabled: boolean): Promise<void> {
+  const wasInMock = useMock;
   useMock = enabled;
+
+  // If we're switching from mock → real, erect the transition gate BEFORE
+  // clearing caches so no racing request sneaks through with stale data.
+  if (wasInMock && !enabled) {
+    beginTransition();
+  }
+
   // Best-effort: notify the mock module. The module may not be loaded yet when
   // mock mode is first activated on startup — that is fine because _mockAllowed
   // defaults to true inside the mock module.
@@ -110,17 +122,34 @@ async function setMockEnabled(enabled: boolean): Promise<void> {
       // Non-fatal
     }
   }
+
+  // If we just started the transition, clear the cache and lower the gate.
+  // The gate was raised above to prevent requests from racing through before
+  // clearCache() completes.
+  if (wasInMock && !enabled) {
+    clearCache();
+    endTransition();
+  }
 }
 
 // ── Token Store ───────────────────────────────────────────────────────────────
 
 let _token: string | null = null;
+let _firstRun: boolean = false;
 
 export function getToken(): string | null {
   return _token;
 }
 export function setToken(token: string | null): void {
   _token = token;
+}
+
+/**
+ * Returns true if the backend reported no users exist (first-run state).
+ * Only meaningful after initializeAuth() has resolved.
+ */
+export function isFirstRun(): boolean {
+  return _firstRun;
 }
 
 // ── Auth Gate ─────────────────────────────────────────────────────────────────
@@ -137,6 +166,50 @@ function resolveAuthGate(): void {
     _authResolve = null;
   }
 }
+
+// ── Transition Gate ────────────────────────────────────────────────────────────
+// When the backend comes online and we flip from mock to real mode, in-flight
+// requests must not proceed with stale mock data. The transition gate blocks
+// all new requests while the mode switch (cache clear + re-auth) completes.
+// A 5-second timeout prevents a stuck transition from hanging the app forever.
+
+const TRANSITION_TIMEOUT_MS = 5_000;
+let _transitionResolve: (() => void) | null = null;
+let _transitionPromise: Promise<void> | null = null;
+let _transitioning = false;
+
+function beginTransition(): void {
+  if (_transitioning) return;
+  _transitioning = true;
+  _transitionPromise = new Promise<void>((resolve) => {
+    _transitionResolve = resolve;
+    // Safety: auto-resolve after timeout so requests are never blocked forever
+    setTimeout(() => {
+      if (_transitionResolve) {
+        _transitionResolve();
+        _transitionResolve = null;
+        _transitioning = false;
+      }
+    }, TRANSITION_TIMEOUT_MS);
+  });
+}
+
+function endTransition(): void {
+  if (_transitionResolve) {
+    _transitionResolve();
+    _transitionResolve = null;
+  }
+  _transitioning = false;
+  _transitionPromise = null;
+}
+
+// Tracks the in-flight (or completed) initializeAuth() promise so that
+// concurrent or repeated callers all await the same single execution.
+// Without this guard a second call — e.g. from +layout.svelte after
+// +page.svelte already ran initializeAuth() and redirected to /app —
+// would re-probe /health, call clearCache(), and re-verify the token,
+// wasting two extra network requests and wiping freshly-cached responses.
+let _initPromise: Promise<void> | null = null;
 
 // ── Auth Initialization ───────────────────────────────────────────────────────
 
@@ -182,8 +255,18 @@ export async function login(email: string, password: string): Promise<string> {
   return data.token;
 }
 
-export async function initializeAuth(): Promise<void> {
-  // 0. Probe backend — if it responds, disable mock mode
+export function initializeAuth(): Promise<void> {
+  // Return the in-flight or completed promise so concurrent / repeated callers
+  // (e.g. +page.svelte then +layout.svelte on the same navigation) share one
+  // execution and avoid redundant health probes, cache clearing, and token
+  // verification requests.
+  if (_initPromise) return _initPromise;
+  _initPromise = _doInitializeAuth();
+  return _initPromise;
+}
+
+async function _doInitializeAuth(): Promise<void> {
+  // 0. Probe backend health — if it responds, disable mock mode
   try {
     const probe = await fetch(`${BASE_URL}${API_PREFIX}/health`, {
       signal: AbortSignal.timeout(3000),
@@ -201,7 +284,31 @@ export async function initializeAuth(): Promise<void> {
     return;
   }
 
-  // 1. Check Tauri store for a saved token
+  // 0b. Check auth status to determine first-run state
+  try {
+    const statusRes = await fetch(`${BASE_URL}${API_PREFIX}/auth/status`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    if (statusRes.ok) {
+      const status = (await statusRes.json()) as {
+        has_users: boolean;
+        registration_open: boolean;
+      };
+      _firstRun = !status.has_users;
+    }
+  } catch {
+    // Non-fatal: assume users exist, proceed normally
+    _firstRun = false;
+  }
+
+  // 1. If no users exist yet (first run), open gate and return immediately.
+  //    The root page will redirect to /auth for registration.
+  if (_firstRun) {
+    resolveAuthGate();
+    return;
+  }
+
+  // 2. Check Tauri store for a saved token
   try {
     const { load: loadStore } = await import("@tauri-apps/plugin-store");
     const store = await loadStore("store.json", {
@@ -211,10 +318,20 @@ export async function initializeAuth(): Promise<void> {
     const stored = await store.get<string>("authToken");
     if (stored) _token = stored;
   } catch {
-    // Not in Tauri or store unavailable
+    // Not in Tauri or store unavailable — try localStorage
   }
 
-  // 2. If we have a token, verify it is still valid
+  // 3. Fall back to localStorage token if Tauri store had nothing
+  if (!_token) {
+    try {
+      const stored = localStorage.getItem("canopy-auth-token");
+      if (stored) _token = stored;
+    } catch {
+      // localStorage unavailable (SSR / blocked)
+    }
+  }
+
+  // 4. If we have a token, verify it is still valid
   if (_token) {
     const valid = await verifyToken(_token);
     if (valid) {
@@ -224,7 +341,7 @@ export async function initializeAuth(): Promise<void> {
     _token = null;
   }
 
-  // 3. No valid token — try dev auto-login (credentials from env only)
+  // 5. No valid stored token — try dev auto-login as FALLBACK (dev mode only)
   const devEmail = import.meta.env.VITE_DEV_EMAIL;
   const devPassword = import.meta.env.VITE_DEV_PASSWORD;
   if (devEmail && devPassword) {
@@ -232,17 +349,18 @@ export async function initializeAuth(): Promise<void> {
       const token = await login(devEmail, devPassword);
       _token = token;
       await saveTokenToStore(token);
+      try {
+        localStorage.setItem("canopy-auth-token", token);
+      } catch {
+        // Non-fatal
+      }
     } catch {
-      // Backend not ready or credentials rejected — fall back to mock mode
-      await setMockEnabled(true);
+      // Dev credentials rejected — no token, will redirect to /auth for login
     }
-  } else {
-    // No dev credentials and no stored token — fall back to mock mode so that
-    // API calls don't fire unauthenticated requests and receive 401 responses.
-    // The app can prompt for credentials and call setToken() + disableMock()
-    // once the user logs in.
-    await setMockEnabled(true);
   }
+  // If still no token after dev login attempt, the root page will redirect
+  // to /auth for manual login. We do NOT fall back to mock mode here so that
+  // real API calls work once the user provides credentials.
 
   // Open the auth gate so queued API requests can proceed
   resolveAuthGate();
@@ -331,7 +449,42 @@ export function clearCache(): void {
 
 // ── Offline Queue ───────────────────────────────────────────────────────────
 
-const offlineQueue: QueuedRequest[] = [];
+const OFFLINE_QUEUE_KEY = "canopy-offline-queue";
+const OFFLINE_QUEUE_MAX = 100;
+const OFFLINE_QUEUE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+function loadQueueFromStorage(): QueuedRequest[] {
+  if (typeof localStorage === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(OFFLINE_QUEUE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as QueuedRequest[];
+    const cutoff = Date.now() - OFFLINE_QUEUE_TTL_MS;
+    return parsed.filter((r) => r.timestamp > cutoff);
+  } catch {
+    return [];
+  }
+}
+
+function saveQueueToStorage(queue: QueuedRequest[]): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(OFFLINE_QUEUE_KEY, JSON.stringify(queue));
+  } catch {
+    // Storage full or unavailable — non-fatal
+  }
+}
+
+function clearQueueFromStorage(): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.removeItem(OFFLINE_QUEUE_KEY);
+  } catch {
+    // Non-fatal
+  }
+}
+
+const offlineQueue: QueuedRequest[] = loadQueueFromStorage();
 export function getOfflineQueue(): readonly QueuedRequest[] {
   return offlineQueue;
 }
@@ -359,10 +512,20 @@ export async function flushOfflineQueue(): Promise<{
       break;
     }
   }
+  // Clear storage only when the queue drained completely
+  if (offlineQueue.length === 0) {
+    clearQueueFromStorage();
+  } else {
+    saveQueueToStorage(offlineQueue);
+  }
   return { succeeded, failed };
 }
 
 function queueForOffline(method: string, path: string, body?: unknown): void {
+  if (offlineQueue.length >= OFFLINE_QUEUE_MAX) {
+    // Discard the oldest item to make room
+    offlineQueue.shift();
+  }
   offlineQueue.push({
     id: crypto.randomUUID(),
     method,
@@ -370,6 +533,7 @@ function queueForOffline(method: string, path: string, body?: unknown): void {
     body,
     timestamp: Date.now(),
   });
+  saveQueueToStorage(offlineQueue);
 }
 
 // ── Core Request ──────────────────────────────────────────────────────────────
@@ -420,6 +584,11 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   // race condition that caused mock data to bleed into live sessions.
   await _authPromise;
 
+  // If a mock→real transition is in progress, wait for it to complete so we
+  // never send a request while the cache is being cleared and re-auth is
+  // running. The transition promise is null when no transition is active.
+  if (_transitionPromise) await _transitionPromise;
+
   // Guard: re-check useMock after the auth gate opens so a flip that happened
   // concurrently during initializeAuth() is always visible here.
   if (useMock) {
@@ -435,6 +604,21 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   }
 
   const method = (options.method ?? "GET").toUpperCase();
+
+  // For mutating requests, generate an idempotency key once so retries reuse
+  // the same key and the backend can deduplicate them.
+  if (method !== "GET") {
+    const existingHeaders = (options.headers ?? {}) as Record<string, string>;
+    if (!existingHeaders["Idempotency-Key"]) {
+      options = {
+        ...options,
+        headers: {
+          ...existingHeaders,
+          "Idempotency-Key": crypto.randomUUID(),
+        },
+      };
+    }
+  }
 
   if (method === "GET") {
     const cached = getCached<T>(path);
@@ -465,6 +649,134 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
       queueForOffline(method, path, body);
     }
     throw error;
+  }
+}
+
+// ── Auth ─────────────────────────────────────────────────────────────────────
+
+export interface AuthStatus {
+  has_users: boolean;
+  registration_open: boolean;
+}
+
+export interface AuthUser {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+}
+
+export interface AuthWorkspace {
+  id: string;
+  name: string;
+}
+
+export interface RegisterResponse {
+  token: string;
+  user: AuthUser;
+  workspace: AuthWorkspace;
+}
+
+export interface LoginResponse {
+  token: string;
+  user: AuthUser;
+}
+
+export const auth = {
+  status: async (): Promise<AuthStatus> => {
+    const res = await fetch(`${BASE_URL}${API_PREFIX}/auth/status`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) throw new ApiError(res.status, "Failed to fetch auth status");
+    return res.json() as Promise<AuthStatus>;
+  },
+
+  register: async (data: {
+    name: string;
+    email: string;
+    password: string;
+  }): Promise<RegisterResponse> => {
+    const res = await fetch(`${BASE_URL}${API_PREFIX}/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) {
+      let body: unknown;
+      try {
+        body = await res.json();
+      } catch {
+        body = await res.text();
+      }
+      const message =
+        typeof body === "object" && body !== null && "error" in body
+          ? String((body as Record<string, unknown>).error)
+          : "Registration failed";
+      throw new ApiError(res.status, message, body);
+    }
+    return res.json() as Promise<RegisterResponse>;
+  },
+
+  login: async (data: {
+    email: string;
+    password: string;
+  }): Promise<LoginResponse> => {
+    const res = await fetch(`${BASE_URL}${API_PREFIX}/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) {
+      let body: unknown;
+      try {
+        body = await res.json();
+      } catch {
+        body = await res.text();
+      }
+      const message =
+        typeof body === "object" && body !== null && "error" in body
+          ? String((body as Record<string, unknown>).error)
+          : "Login failed";
+      throw new ApiError(res.status, message, body);
+    }
+    return res.json() as Promise<LoginResponse>;
+  },
+};
+
+/**
+ * Persist an auth token to both Tauri store and localStorage.
+ * Safe to call in browser-only context (Tauri path will no-op gracefully).
+ */
+export async function persistToken(token: string): Promise<void> {
+  _token = token;
+  await saveTokenToStore(token);
+  try {
+    localStorage.setItem("canopy-auth-token", token);
+  } catch {
+    // Non-fatal
+  }
+}
+
+/**
+ * Clear the stored auth token from all persistence layers.
+ */
+export async function clearToken(): Promise<void> {
+  _token = null;
+  try {
+    const { load: loadStore } = await import("@tauri-apps/plugin-store");
+    const store = await loadStore("store.json", {
+      autoSave: true,
+      defaults: {},
+    });
+    await store.delete("authToken");
+    await store.save();
+  } catch {
+    // Not in Tauri or store unavailable
+  }
+  try {
+    localStorage.removeItem("canopy-auth-token");
+  } catch {
+    // Non-fatal
   }
 }
 
@@ -714,16 +1026,31 @@ export const projects = {
 // ── Costs ─────────────────────────────────────────────────────────────────────
 
 export const costs = {
-  summary: () => request<CostSummary>("/costs/summary"),
-  byAgent: () => request<{ agents: AgentCostBreakdown[] }>("/costs/by-agent"),
-  byModel: () => request<{ models: ModelCostBreakdown[] }>("/costs/by-model"),
-  policies: () => request<{ policies: BudgetPolicy[] }>("/budgets"),
-  incidents: () =>
-    request<{ incidents: BudgetIncident[] }>("/budgets/incidents"),
-  daily: (params?: { from?: string; to?: string }) => {
+  summary: (workspaceId?: string) => {
+    const qs = workspaceId ? `?workspace_id=${workspaceId}` : "";
+    return request<CostSummary>(`/costs/summary${qs}`);
+  },
+  byAgent: (workspaceId?: string) => {
+    const qs = workspaceId ? `?workspace_id=${workspaceId}` : "";
+    return request<{ agents: AgentCostBreakdown[] }>(`/costs/by-agent${qs}`);
+  },
+  byModel: (workspaceId?: string) => {
+    const qs = workspaceId ? `?workspace_id=${workspaceId}` : "";
+    return request<{ models: ModelCostBreakdown[] }>(`/costs/by-model${qs}`);
+  },
+  policies: (workspaceId?: string) => {
+    const qs = workspaceId ? `?workspace_id=${workspaceId}` : "";
+    return request<{ policies: BudgetPolicy[] }>(`/budgets${qs}`);
+  },
+  incidents: (workspaceId?: string) => {
+    const qs = workspaceId ? `?workspace_id=${workspaceId}` : "";
+    return request<{ incidents: BudgetIncident[] }>(`/budgets/incidents${qs}`);
+  },
+  daily: (params?: { from?: string; to?: string; workspace_id?: string }) => {
     const qs = new URLSearchParams();
     if (params?.from) qs.set("from", params.from);
     if (params?.to) qs.set("to", params.to);
+    if (params?.workspace_id) qs.set("workspace_id", params.workspace_id);
     const query = qs.toString() ? `?${qs.toString()}` : "";
     return request<{ points: Array<{ date: string; cost_cents: number }> }>(
       `/costs/daily${query}`,
@@ -1475,6 +1802,18 @@ export async function disableMock(): Promise<void> {
 }
 export function isMockEnabled(): boolean {
   return useMock;
+}
+
+/**
+ * Reset the singleton initializeAuth() promise so that the next call to
+ * initializeAuth() re-probes the backend and re-reads the token.
+ *
+ * Call this after a successful login or registration so that the /app layout
+ * guard sees the freshly-persisted token instead of the cached "no-token"
+ * state from the first run of initializeAuth().
+ */
+export function resetInitPromise(): void {
+  _initPromise = null;
 }
 
 /**

--- a/desktop/src/lib/api/types.ts
+++ b/desktop/src/lib/api/types.ts
@@ -215,6 +215,8 @@ export interface CanopyAgent {
 export interface AgentCreateRequest {
   name: string;
   display_name: string;
+  slug?: string;
+  workspace_id?: string;
   avatar_emoji?: string;
   role: string;
   adapter: AdapterType;
@@ -373,6 +375,7 @@ export interface Project {
   name: string;
   description: string | null;
   status: ProjectStatus;
+  workspace_id?: string;
   workspace_path: string | null;
   goal_count: number;
   issue_count: number;

--- a/desktop/src/lib/components/issues/IssueCard.svelte
+++ b/desktop/src/lib/components/issues/IssueCard.svelte
@@ -2,6 +2,7 @@
 <!-- Compact issue card for kanban/list with HTML5 drag-and-drop -->
 <script lang="ts">
   import type { Issue } from '$api/types';
+  import { resolveAssigneeName } from '$lib/stores/issues.svelte';
   import TimeAgo from '$lib/components/shared/TimeAgo.svelte';
 
   interface Props {
@@ -34,6 +35,7 @@
   }
 
   let priorityColor = $derived(PRIORITY_COLORS[issue.priority] ?? '#666');
+  let assigneeName = $derived(resolveAssigneeName(issue));
 </script>
 
 <article
@@ -63,10 +65,10 @@
   {/if}
 
   <footer class="ic-footer">
-    {#if issue.assignee_name}
-      <span class="ic-assignee" aria-label="Assigned to {issue.assignee_name}">
-        <span class="ic-avatar" aria-hidden="true">{issue.assignee_name[0].toUpperCase()}</span>
-        <span class="ic-assignee-name">{issue.assignee_name}</span>
+    {#if issue.assignee_id}
+      <span class="ic-assignee" aria-label="Assigned to {assigneeName}">
+        <span class="ic-avatar" aria-hidden="true">{assigneeName[0].toUpperCase()}</span>
+        <span class="ic-assignee-name">{assigneeName}</span>
       </span>
     {:else}
       <span class="ic-unassigned" aria-label="Unassigned">Unassigned</span>

--- a/desktop/src/lib/components/issues/IssueForm.svelte
+++ b/desktop/src/lib/components/issues/IssueForm.svelte
@@ -53,8 +53,11 @@
       assignee_name: assignee?.display_name ?? null,
       labels,
     };
-    onSubmit(data);
-    submitting = false;
+    try {
+      await onSubmit(data);
+    } finally {
+      submitting = false;
+    }
   }
 
   const PRIORITIES: IssuePriority[] = ['low', 'medium', 'high', 'critical'];

--- a/desktop/src/lib/components/issues/IssueList.svelte
+++ b/desktop/src/lib/components/issues/IssueList.svelte
@@ -2,7 +2,7 @@
 <!-- Flat list view of issues with compact 40px rows -->
 <script lang="ts">
   import type { Issue } from '$api/types';
-  import { issuesStore } from '$lib/stores/issues.svelte';
+  import { issuesStore, resolveAssigneeName } from '$lib/stores/issues.svelte';
   import TimeAgo from '$lib/components/shared/TimeAgo.svelte';
 
   interface Props {
@@ -74,6 +74,7 @@
     {#each issues as issue (issue.id)}
       {@const priority = PRIORITY_ICONS[issue.priority]}
       {@const statusInfo = STATUS_LABELS[issue.status]}
+      {@const assigneeName = resolveAssigneeName(issue)}
       <button
         class="il-row"
         class:il-row--selected={issuesStore.selected?.id === issue.id}
@@ -112,10 +113,10 @@
         </span>
 
         <!-- Assignee -->
-        <span class="il-assignee" aria-label={issue.assignee_name ? 'Assigned to ' + issue.assignee_name : 'Unassigned'}>
-          {#if issue.assignee_name}
-            <span class="il-avatar" aria-hidden="true">{issue.assignee_name[0].toUpperCase()}</span>
-            <span class="il-assignee-name">{issue.assignee_name}</span>
+        <span class="il-assignee" aria-label={issue.assignee_id ? 'Assigned to ' + assigneeName : 'Unassigned'}>
+          {#if issue.assignee_id}
+            <span class="il-avatar" aria-hidden="true">{assigneeName[0].toUpperCase()}</span>
+            <span class="il-assignee-name">{assigneeName}</span>
           {:else}
             <span class="il-no-assignee">—</span>
           {/if}
@@ -144,7 +145,7 @@
               class:il-dispatch-btn--loading={dispatching[issue.id]}
               onclick={(e) => handleDispatch(e, issue)}
               disabled={dispatching[issue.id]}
-              aria-label="Dispatch issue to {issue.assignee_name}"
+              aria-label="Dispatch issue to {assigneeName}"
               type="button"
             >
               {#if dispatching[issue.id]}
@@ -153,7 +154,7 @@
                 <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
                   <path d="M22 2L11 13M22 2l-7 20-4-9-9-4 20-7z" />
                 </svg>
-                <span class="il-dispatch-agent">{issue.assignee_name}</span>
+                <span class="il-dispatch-agent">{assigneeName}</span>
               {/if}
             </button>
           {:else}

--- a/desktop/src/lib/components/issues/IssueTable.svelte
+++ b/desktop/src/lib/components/issues/IssueTable.svelte
@@ -2,7 +2,7 @@
 <!-- Sortable data table view for issues -->
 <script lang="ts">
   import type { Issue } from '$api/types';
-  import { issuesStore } from '$lib/stores/issues.svelte';
+  import { issuesStore, resolveAssigneeName } from '$lib/stores/issues.svelte';
   import TimeAgo from '$lib/components/shared/TimeAgo.svelte';
 
   let dispatching = $state<Record<string, boolean>>({});
@@ -133,6 +133,7 @@
       </thead>
       <tbody>
         {#each sorted as issue (issue.id)}
+          {@const assigneeName = resolveAssigneeName(issue)}
           <tr
             class="it-row"
             class:it-row--selected={issuesStore.selected?.id === issue.id}
@@ -157,10 +158,10 @@
               <span class="it-status-text">{STATUS_LABELS[issue.status] ?? issue.status}</span>
             </td>
             <td class="it-td">
-              {#if issue.assignee_name}
+              {#if issue.assignee_id}
                 <div class="it-assignee">
-                  <span class="it-avatar" aria-hidden="true">{issue.assignee_name[0].toUpperCase()}</span>
-                  <span class="it-assignee-name">{issue.assignee_name}</span>
+                  <span class="it-avatar" aria-hidden="true">{assigneeName[0].toUpperCase()}</span>
+                  <span class="it-assignee-name">{assigneeName}</span>
                 </div>
               {:else}
                 <span class="it-none">—</span>
@@ -192,7 +193,7 @@
                   class:it-dispatch-btn--loading={dispatching[issue.id]}
                   onclick={(e) => handleDispatch(e, issue)}
                   disabled={dispatching[issue.id]}
-                  aria-label="Dispatch issue to {issue.assignee_name}"
+                  aria-label="Dispatch issue to {assigneeName}"
                   type="button"
                 >
                   {#if dispatching[issue.id]}
@@ -201,7 +202,7 @@
                     <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
                       <path d="M22 2L11 13M22 2l-7 20-4-9-9-4 20-7z" />
                     </svg>
-                    <span class="it-dispatch-agent">{issue.assignee_name}</span>
+                    <span class="it-dispatch-agent">{assigneeName}</span>
                   {/if}
                 </button>
               {/if}

--- a/desktop/src/lib/services/template-deploy.ts
+++ b/desktop/src/lib/services/template-deploy.ts
@@ -5,6 +5,7 @@
 import type { CanopyAgent } from "$api/types";
 import { workspaceStore } from "$lib/stores/workspace.svelte";
 import { agentsStore } from "$lib/stores/agents.svelte";
+import { toastStore } from "$lib/stores/toasts.svelte";
 import { isTauri } from "$lib/utils/platform";
 import { isMockEnabled } from "$api/client";
 
@@ -12,7 +13,9 @@ export interface DeployResult {
   success: boolean;
   workspaceId: string | null;
   agentCount: number;
+  failedAgents: Array<{ name: string; error: string }>;
   error?: string;
+  warnings?: string[];
 }
 
 /**
@@ -45,8 +48,9 @@ export async function deployTemplate(
 
     // Step 3: Register agents in mock layer BEFORE setting active workspace
     // (so any fetchAgents triggered by setActiveWorkspace finds them)
+    let failedAgents: Array<{ name: string; error: string }> = [];
     if (agents.length > 0) {
-      await registerAgents(agents, ws.id);
+      failedAgents = await registerAgents(agents, ws.id);
     }
 
     // Step 4: Scaffold .canopy/ directory on disk via Tauri IPC
@@ -79,13 +83,15 @@ export async function deployTemplate(
     return {
       success: true,
       workspaceId: ws.id,
-      agentCount: agents.length,
+      agentCount: agents.length - failedAgents.length,
+      failedAgents,
     };
   } catch (e) {
     return {
       success: false,
       workspaceId: null,
       agentCount: 0,
+      failedAgents: [],
       error: (e as Error).message,
     };
   }
@@ -123,11 +129,13 @@ async function loadBundledTemplate(templateId: string): Promise<CanopyAgent[]> {
  * 1. Persist in mock layer (survives navigation / fetchAgents cycles)
  * 2. Inject into Svelte store for instant UI
  * 3. Persist to real backend if available
+ *
+ * Returns a list of agents that failed to register (empty on full success).
  */
 async function registerAgents(
   agents: CanopyAgent[],
   workspaceId: string,
-): Promise<void> {
+): Promise<Array<{ name: string; error: string }>> {
   if (isMockEnabled()) {
     // Mock mode only: persist agents to localStorage so they survive
     // fetchAgents() calls and page reloads while offline.
@@ -136,6 +144,7 @@ async function registerAgents(
 
     // Inject into store immediately so the UI reflects them without a refetch.
     agentsStore.agents = agents;
+    return [];
   } else {
     // Real backend available: create agents via API. The store will be
     // refreshed by the subsequent fetchAgents() call, so we do not need to
@@ -144,25 +153,67 @@ async function registerAgents(
     try {
       const { agents: agentsApi } = await import("$api/client");
 
-      await Promise.allSettled(
-        agents.map((agent) =>
-          agentsApi.create({
+      const results = await Promise.allSettled(
+        agents.map((agent) => {
+          // Derive slug from agent.name (the short ID, e.g. "growth-director")
+          const slug = (agent.name || agent.display_name || "agent")
+            .toLowerCase()
+            .replace(/[^a-z0-9-]/g, "-")
+            .replace(/-+/g, "-")
+            .replace(/^-|-$/g, "");
+
+          // Normalize adapter: template may use underscores, schema requires hyphens
+          const adapter = (agent.adapter || "claude-code").replace(/_/g, "-");
+
+          return agentsApi.create({
+            slug,
             name: agent.display_name || agent.name,
-            display_name: agent.display_name,
-            avatar_emoji: agent.avatar_emoji,
+            display_name: agent.display_name || agent.name,
             role: agent.role,
-            adapter: agent.adapter,
-            model: agent.model,
+            adapter,
+            model: agent.model || "sonnet",
+            workspace_id: workspaceId,
+            avatar_emoji: agent.avatar_emoji,
             system_prompt: agent.system_prompt,
-            config: { ...agent.config, workspace_id: workspaceId },
-            skills: agent.skills,
-          }),
-        ),
+            config: agent.config || {},
+          });
+        }),
       );
-    } catch {
-      // API creation failed — fall back to store-only injection so the
+
+      // Collect failed registrations
+      const failures: Array<{ name: string; error: string }> = [];
+      results.forEach((result, index) => {
+        if (result.status === "rejected") {
+          const agent = agents[index];
+          failures.push({
+            name: agent.display_name || agent.name,
+            error:
+              result.reason instanceof Error
+                ? result.reason.message
+                : String(result.reason),
+          });
+        }
+      });
+
+      if (failures.length > 0) {
+        const detail = failures.map((f) => `${f.name}: ${f.error}`).join("\n");
+        toastStore.warning(
+          `${failures.length} agent${failures.length > 1 ? "s" : ""} failed to register`,
+          detail,
+          8000,
+        );
+      }
+
+      return failures;
+    } catch (err) {
+      // Entire API call failed — fall back to store-only injection so the
       // user at least sees something, but do NOT persist to localStorage.
       agentsStore.agents = agents;
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      return agents.map((a) => ({
+        name: a.display_name || a.name,
+        error: errorMsg,
+      }));
     }
   }
 }

--- a/desktop/src/lib/stores/costs.svelte.ts
+++ b/desktop/src/lib/stores/costs.svelte.ts
@@ -22,6 +22,8 @@ class CostsStore {
   lastFetched = $state<Date | null>(null);
 
   dateRange = $state<DateRange>("30d");
+  // Tracks the active workspace so date-range changes can re-fetch scoped data
+  private _workspaceId: string | undefined = undefined;
 
   summary = $state<CostSummary>({
     today_cents: 0,
@@ -99,14 +101,14 @@ class CostsStore {
 
   // ── Methods ────────────────────────────────────────────────────────────────
 
-  async fetch(): Promise<void> {
+  async fetch(workspaceId?: string): Promise<void> {
     this.isLoading = true;
     this.error = null;
     try {
       const [summaryData, agentData, modelData] = await Promise.all([
-        costsApi.summary(),
-        costsApi.byAgent(),
-        costsApi.byModel(),
+        costsApi.summary(workspaceId),
+        costsApi.byAgent(workspaceId),
+        costsApi.byModel(workspaceId),
       ]);
       this.summary = summaryData;
       this.agentBreakdown = agentData.agents ?? [];
@@ -121,11 +123,11 @@ class CostsStore {
     }
   }
 
-  async fetchPolicies(): Promise<void> {
+  async fetchPolicies(workspaceId?: string): Promise<void> {
     try {
       const [policiesData, incidentsData] = await Promise.all([
-        costsApi.policies(),
-        costsApi.incidents(),
+        costsApi.policies(workspaceId),
+        costsApi.incidents(workspaceId),
       ]);
       this.policies = policiesData.policies ?? [];
       this.incidents = incidentsData.incidents ?? [];
@@ -136,7 +138,7 @@ class CostsStore {
     }
   }
 
-  async fetchTrends(): Promise<void> {
+  async fetchTrends(workspaceId?: string): Promise<void> {
     try {
       const to = new Date();
       const daysBack =
@@ -144,7 +146,11 @@ class CostsStore {
       const from = new Date(to);
       from.setDate(from.getDate() - daysBack);
       const fmt = (d: Date) => d.toISOString().slice(0, 10);
-      const data = await costsApi.daily({ from: fmt(from), to: fmt(to) });
+      const data = await costsApi.daily({
+        from: fmt(from),
+        to: fmt(to),
+        workspace_id: workspaceId,
+      });
       this.dailyTrend = data.points ?? [];
     } catch {
       // Endpoint may not exist yet — fail silently with empty trend
@@ -152,15 +158,16 @@ class CostsStore {
     }
   }
 
-  async fetchAll(): Promise<void> {
-    await this.fetch();
-    await this.fetchTrends();
-    await this.fetchPolicies();
+  async fetchAll(workspaceId?: string): Promise<void> {
+    this._workspaceId = workspaceId;
+    await this.fetch(workspaceId);
+    await this.fetchTrends(workspaceId);
+    await this.fetchPolicies(workspaceId);
   }
 
   setDateRange(range: DateRange): void {
     this.dateRange = range;
-    void this.fetchTrends();
+    void this.fetchTrends(this._workspaceId);
   }
 }
 

--- a/desktop/src/lib/stores/dashboard.svelte.ts
+++ b/desktop/src/lib/stores/dashboard.svelte.ts
@@ -13,13 +13,7 @@ class DashboardStore {
   error = $state<string | null>(null);
   lastFetched = $state<Date | null>(null);
 
-  kpis = $state<DashboardKpis>({
-    active_agents: 0,
-    total_agents: 0,
-    live_runs: 0,
-    open_issues: 0,
-    budget_remaining_pct: 0,
-  });
+  kpis = $state<DashboardKpis | null>(null);
   liveRuns = $state<LiveRun[]>([]);
   recentActivity = $state<ActivityEvent[]>([]);
   financeSummary = $state<FinanceSummary | null>(null);

--- a/desktop/src/lib/stores/issues.svelte.ts
+++ b/desktop/src/lib/stores/issues.svelte.ts
@@ -2,6 +2,16 @@
 import type { Issue, IssueStatus, IssuePriority } from "$api/types";
 import { issues as issuesApi } from "$api/client";
 import { toastStore } from "./toasts.svelte";
+import { agentsStore } from "./agents.svelte";
+
+export function resolveAssigneeName(issue: Issue): string {
+  if (issue.assignee_name) return issue.assignee_name;
+  if (issue.assignee_id) {
+    const agent = agentsStore.agents.find((a) => a.id === issue.assignee_id);
+    return agent?.display_name ?? agent?.name ?? "Unknown Agent";
+  }
+  return "Unassigned";
+}
 
 type SortField = "created_at" | "updated_at" | "priority" | "title";
 type SortDirection = "asc" | "desc";

--- a/desktop/src/lib/stores/sessions.svelte.ts
+++ b/desktop/src/lib/stores/sessions.svelte.ts
@@ -1,7 +1,7 @@
 // src/lib/stores/sessions.svelte.ts
 // Observability store for session list, detail, and live transcript streaming
 
-import type { Session, Message } from "$api/types";
+import type { Session, Message, ActivityEvent } from "$api/types";
 import { sessions as sessionsApi, messages as messagesApi } from "$api/client";
 import { connectSSE, type StreamController } from "$api/sse";
 import { toastStore } from "./toasts.svelte";
@@ -272,6 +272,81 @@ class SessionsStore {
     if (!session) {
       this.transcript = [];
       this.stopLiveStream();
+    }
+  }
+
+  // ── Live activity event handling ────────────────────────────────────────────
+  // Called from the app layout whenever the activity store emits an event.
+  // Keeps the session list in sync during live agent execution without
+  // requiring a full refetch.
+
+  handleActivityEvent(event: ActivityEvent): void {
+    const meta = event.metadata as Record<string, unknown>;
+    const sessionId =
+      typeof meta.session_id === "string" ? meta.session_id : null;
+
+    if (event.type === "session_started") {
+      if (!sessionId) return;
+      // Add a new active session entry if we don't already have it
+      const exists = this.sessions.some((s) => s.id === sessionId);
+      if (!exists) {
+        const newSession: Session = {
+          id: sessionId,
+          agent_id: event.agent_id ?? "",
+          agent_name: event.agent_name ?? "",
+          title: typeof meta.title === "string" ? meta.title : null,
+          status: "active",
+          message_count: 0,
+          token_usage: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+          cost_cents: 0,
+          started_at: event.created_at,
+          completed_at: null,
+          created_at: event.created_at,
+        };
+        this.sessions = [newSession, ...this.sessions];
+      } else {
+        // Already in list — just mark as active
+        this.sessions = this.sessions.map((s) =>
+          s.id === sessionId ? { ...s, status: "active" as const } : s,
+        );
+      }
+      return;
+    }
+
+    if (
+      event.type === "session_completed" ||
+      event.type === "heartbeat_completed" ||
+      event.type === "heartbeat_failed"
+    ) {
+      if (!sessionId) return;
+      const finalStatus: Session["status"] =
+        event.type === "session_completed" ||
+        event.type === "heartbeat_completed"
+          ? "completed"
+          : "failed";
+      this.sessions = this.sessions.map((s) =>
+        s.id === sessionId
+          ? {
+              ...s,
+              status: finalStatus,
+              completed_at:
+                typeof meta.completed_at === "string"
+                  ? meta.completed_at
+                  : new Date().toISOString(),
+            }
+          : s,
+      );
+      // Sync detail view if this is the currently selected session
+      if (this.selectedSession?.id === sessionId) {
+        this.selectedSession = {
+          ...this.selectedSession,
+          status: finalStatus,
+          completed_at:
+            typeof meta.completed_at === "string"
+              ? meta.completed_at
+              : new Date().toISOString(),
+        };
+      }
     }
   }
 }

--- a/desktop/src/lib/stores/spawn.svelte.ts
+++ b/desktop/src/lib/stores/spawn.svelte.ts
@@ -87,14 +87,12 @@ class SpawnStore {
       const fresh = await spawnApi.list();
       // Merge fresh data — preserve ordering of existing instances
       const freshMap = new Map(fresh.map((i) => [i.id, i]));
-      this.instances = this.instances.map((i) => freshMap.get(i.id) ?? i);
-      // Append any new instances not yet in our list
+      const merged = this.instances.map((i) => freshMap.get(i.id) ?? i);
+      // Collect truly new instances not yet in our list (snapshot existingIds
+      // before any mutation to avoid checking against partially-updated state)
       const existingIds = new Set(this.instances.map((i) => i.id));
-      for (const f of fresh) {
-        if (!existingIds.has(f.id)) {
-          this.instances = [f, ...this.instances];
-        }
-      }
+      const newInstances = fresh.filter((f) => !existingIds.has(f.id));
+      this.instances = [...newInstances, ...merged];
       this.error = null;
     } catch (e) {
       const msg = (e as Error).message;

--- a/desktop/src/lib/stores/workspace.svelte.ts
+++ b/desktop/src/lib/stores/workspace.svelte.ts
@@ -2,6 +2,8 @@
 import { browser } from "$app/environment";
 import { isTauri } from "$lib/utils/platform";
 import type { Workspace as BackendWorkspace } from "$api/types";
+import { toastStore } from "./toasts.svelte";
+import { workspaces as workspacesApi, isMockEnabled } from "$api/client";
 
 /**
  * Extract the `description` field from YAML frontmatter in a markdown file.
@@ -111,6 +113,10 @@ class WorkspaceStore {
       this.lastScan = result;
       return result;
     } catch {
+      toastStore.warning(
+        "Workspace scan failed",
+        `.canopy directory not found at ${path}`,
+      );
       return null;
     }
   }
@@ -295,8 +301,26 @@ class WorkspaceStore {
     const rawPath =
       directory ?? `~/.canopy/${name.toLowerCase().replace(/\s+/g, "-")}`;
     const resolvedPath = await resolveHomePath(rawPath);
+
+    let backendId: string | null = null;
+
+    // Create workspace in backend so agents can reference it
+    if (!isMockEnabled()) {
+      try {
+        const created = await workspacesApi.create({
+          name,
+          path: resolvedPath,
+        });
+        backendId =
+          (created as any).workspace?.id ?? (created as any).id ?? null;
+      } catch (e) {
+        // Backend create failed — fall back to local-only
+        console.warn("[WorkspaceStore] Backend workspace create failed:", e);
+      }
+    }
+
     const ws: LocalWorkspace = {
-      id: crypto.randomUUID(),
+      id: backendId ?? crypto.randomUUID(),
       path: resolvedPath,
       name,
       addedAt: new Date().toISOString(),

--- a/desktop/src/routes/app/+layout.svelte
+++ b/desktop/src/routes/app/+layout.svelte
@@ -14,6 +14,7 @@ import Sidebar from '$lib/components/layout/Sidebar.svelte';
   import CommandPalette from '$lib/components/layout/CommandPalette.svelte';
   import ActivityWidget from '$lib/components/activity/ActivityWidget.svelte';
   import { activityStore } from '$lib/stores/activity.svelte';
+  import { sessionsStore } from '$lib/stores/sessions.svelte';
   import { isTauri, isMacOS } from '$lib/utils/platform';
   import { initializeAuth, getToken, isMockEnabled, workspaces, agents } from '$api/client';
 
@@ -27,6 +28,16 @@ import Sidebar from '$lib/components/layout/Sidebar.svelte';
 
   // Initialize theme
   $effect(() => { void themeStore.resolved; });
+
+  // Forward session-related activity events to the sessions store so the
+  // session list stays current during live execution without a full refetch.
+  let _lastForwardedActivityId = $state<string | null>(null);
+  $effect(() => {
+    const latest = activityStore.events[0];
+    if (!latest || latest.id === _lastForwardedActivityId) return;
+    _lastForwardedActivityId = latest.id;
+    sessionsStore.handleActivityEvent(latest);
+  });
 
   // Sidebar collapsed state — persisted to localStorage
   let sidebarCollapsed = $state(false);

--- a/desktop/src/routes/app/settings/tabs/GeneralSettings.svelte
+++ b/desktop/src/routes/app/settings/tabs/GeneralSettings.svelte
@@ -1,6 +1,24 @@
 <!-- src/routes/app/settings/tabs/GeneralSettings.svelte -->
 <script lang="ts">
+  import { goto } from '$app/navigation';
   import { settingsStore } from '$lib/stores/settings.svelte';
+  import { clearToken, clearCache } from '$api/client';
+
+  let loggingOut = $state(false);
+
+  async function handleLogout() {
+    loggingOut = true;
+    await clearToken();
+    clearCache();
+    try {
+      localStorage.removeItem('canopy-workspaces');
+      localStorage.removeItem('canopy-active-workspace');
+      localStorage.removeItem('canopy-onboarding');
+      localStorage.removeItem('canopy-onboarding-complete');
+      localStorage.removeItem('canopy-offline-queue');
+    } catch { /* non-fatal */ }
+    goto('/');
+  }
 
   const ADAPTER_OPTIONS: { value: string; label: string }[] = [
     { value: 'osa',         label: 'OSA (default)' },
@@ -63,6 +81,22 @@
         oninput={(e) => settingsStore.update('default_model', (e.target as HTMLInputElement).value)}
       />
     </div>
+  </div>
+</section>
+
+<section class="stg-logout-section">
+  <div class="stg-logout-card">
+    <div class="stg-logout-info">
+      <span class="stg-logout-title">Log Out</span>
+      <span class="stg-logout-desc">Sign out of your account and clear all local session data.</span>
+    </div>
+    <button
+      class="stg-logout-btn"
+      onclick={handleLogout}
+      disabled={loggingOut}
+    >
+      {loggingOut ? 'Logging out...' : 'Log Out'}
+    </button>
   </div>
 </section>
 
@@ -142,4 +176,54 @@
   }
 
   .stg-select:focus { border-color: var(--border-focus); }
+
+  .stg-logout-section {
+    max-width: 640px;
+    margin-top: 32px;
+  }
+
+  .stg-logout-card {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-danger, #ef4444);
+    border-radius: var(--radius-md);
+    padding: 20px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+  }
+
+  .stg-logout-info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .stg-logout-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .stg-logout-desc {
+    font-size: 12px;
+    color: var(--text-tertiary);
+    line-height: 1.5;
+  }
+
+  .stg-logout-btn {
+    padding: 8px 20px;
+    font-size: 13px;
+    font-weight: 500;
+    color: #fff;
+    background: var(--color-danger, #ef4444);
+    border: none;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    white-space: nowrap;
+    transition: opacity var(--transition-fast);
+  }
+
+  .stg-logout-btn:hover { opacity: 0.9; }
+  .stg-logout-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 </style>


### PR DESCRIPTION
## Summary
- **Template deploy**: surfaces per-agent failures via toast, sends `slug` + `workspace_id` + `display_name`, normalizes adapter hyphens, creates workspace in backend before registering agents
- **Auth transition gate**: blocks requests during mock-to-real switch to prevent mixed state
- **Session list**: reactively updates via activity SSE events (no polling)
- **Assignee names**: fallback chain — API response → agent store lookup → "Unassigned"
- **Workspace scan**: shows toast on failure instead of silent error
- **Offline queue**: persisted to localStorage with 100-item cap and 24h TTL
- **Idempotency-Key**: generated for all mutating requests, reused across retries
- **Logout button**: added to Settings > General — clears JWT, cache, localStorage
- **Types**: added `slug?` and `workspace_id?` to `AgentCreateRequest`

## Bugs Fixed
- F-01: Template deploy silently swallows failures
- F-02: Auth token race during mock-to-real transition
- F-03: Session list doesn't update during live execution
- F-04: Assignee names always blank
- F-05: Workspace scan failure is silent
- F-06: Offline queue not persisted across restart

## Test plan
- [ ] Deploy Growth OS → all 36 agents register (no silent failures)
- [ ] Log out via Settings > General → redirects to login, clears all data
- [ ] Run agent → session list updates in real-time without refresh
- [ ] Assign agent to issue → name shows (not blank or machine slug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)