### PR TITLE
Make the ownership boundaries say who is inside one right now

### DIFF
--- a/.knos/decisions.md
+++ b/.knos/decisions.md
@@ -2,6 +2,14 @@
 
 <!-- Written by `knos export`. Commit this file. -->
 
+<!--
+Reading this file needs nothing installed: it is plain markdown, and a fresh
+clone picks it up as-is. The live claim/withhold server is a separate, optional
+step - `pip install knos` (Python 3.10+), which the MCP entry launches as
+`python -m knos.mcp`. Without it, everything below still reads normally.
+-->
+
+
 A second clone reads this on its first question — it is one of the decision
 records knos looks for. Nothing here is private: secrets and private paths
 never reach it.

--- a/.knos/decisions.md
+++ b/.knos/decisions.md
@@ -1,0 +1,22 @@
+# Decisions and current work
+
+<!-- Written by `knos export`. Commit this file. -->
+
+A second clone reads this on its first question — it is one of the decision
+records knos looks for. Nothing here is private: secrets and private paths
+never reach it.
+
+
+## Decisions
+
+- **ownership boundaries** — Three agents work this monorepo. `@devops-engineer` owns `canopy/` root, `docs/`, `.github/` and `packages/`; `@backend-elixir` owns `backend/`; `@frontend-svelte` owns `desktop/` and `src-tauri/`. Do not modify files outside your ownership without explicit instruction.  _(CLAUDE.md)_
+- **make doctor first, every session** — Verify tool versions match `.tool-versions` before writing any code. Mismatched tooling is the number one source of build drift.  _(CLAUDE.md)_
+- **read the authoritative docs first** — `docs/01-foundation.md` for architecture, `docs/02-frontend-design.md` for UX, `docs/04-platform-breakdown.md` for the feature inventory.  _(CLAUDE.md, CONTRIBUTING.md)_
+- **claims expire on their own** — Issue locks are released by an expiry worker rather than held until something clears them.  _(backend/lib/canopy/issues/lock_expiry_worker.ex)_
+
+## Being worked on right now
+
+_Nothing claimed._
+
+---
+<sub>knos export. Claims lapse after 30 minutes.</sub>

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "knos": {
+      "command": "python",
+      "args": [
+        "-m",
+        "knos.mcp"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
`CLAUDE.md`: *"Three agents work this monorepo. Respect boundaries strictly... Do not modify files outside your ownership without explicit instruction."*

That table is the right rule and it is static. It says who owns `backend/`; it cannot say that `@backend-elixir` is mid-change in `sessions/blocks.ex` right now. The boundary holds for planned work and gives nothing for the case where two agents are legitimately inside the same boundary at the same time.

You already reached for the dynamic half once — `issues/lock_expiry_worker.ex` exists because a lock nobody releases is worse than no lock. Same conclusion, one level down: claims lapse after 30 minutes so a crashed agent cannot hold work forever.

**What's in the PR**

- `.knos/decisions.md` — the ownership table and the standing session rules as a record any agent reads, each line citing its source file. Plain markdown; a fresh clone reads it with nothing installed.
- `.mcp.json` — one server, three tools, stdio.

**Disclosure:** I wrote Knos. It is a local MCP server — three tools, no ports, no network, no account, no model download. I seeded the record from your own docs rather than mine so it is checkable rather than promotional. If a third-party entry isn't wanted, close it; the `.knos/decisions.md` half needs no install and works as plain markdown either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)